### PR TITLE
Стилізація NeedHelpModal

### DIFF
--- a/src/components/SideBar/NeedHelp/NeedHelpModal/need-help-modal.module.css
+++ b/src/components/SideBar/NeedHelp/NeedHelpModal/need-help-modal.module.css
@@ -55,7 +55,7 @@ form {
 @media only screen and (min-width: 768px) {
   .modalControl,
   .modalControlText {
-    width: 352px;
+    /* width: 352px; */
   }
 }
 


### PR DESCRIPTION
Компонент CommonModal огортає модальне вікно NeedHelpModal. Компонент CommonModal на екранах більше 768px має ширину меньшу ніж повинно мати модальне вікно NeedHelpModal. Якщо збільшити ширину в стилях CommonModal, то це впливає на ширину інших модальних вікон. Тому, щоб поля вводу та кнопка Send компонента NeedHelpModal не виходили за рамки огортаючого їх компонента, я прибрав збільшення їх ширини при розмірах екрану більше 768px